### PR TITLE
chore: rename the files to fix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -418,11 +418,11 @@ $RECYCLE.BIN/
 # *.dll, *.exe, *.pdb are already handled by bin/obj exclusions
 
 tasks
-src/LightMapper/obj/
-src/LightMapper.Extensions.DependencyInjection/obj/
-tests/LightMapper.Extensions.DependencyInjection.Tests/obj/
-tests/LightMapper.Tests/obj/
-src/LightMapper/bin/
-src/LightMapper.Extensions.DependencyInjection/bin/
-tests/LightMapper.Extensions.DependencyInjection.Tests/bin/
-tests/LightMapper.Tests/bin/
+src/HaloMapper/obj/
+src/HaloMapper.Extensions.DependencyInjection/obj/
+tests/HaloMapper.Extensions.DependencyInjection.Tests/obj/
+tests/HaloMapper.Tests/obj/
+src/HaloMapper/bin/
+src/HaloMapper.Extensions.DependencyInjection/bin/
+tests/HaloMapper.Extensions.DependencyInjection.Tests/bin/
+tests/HaloMapper.Tests/bin/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,9 +20,9 @@
 
   <!-- Common package metadata -->
   <PropertyGroup>
-    <Authors>LightMapper Contributors</Authors>
-    <Company>LightMapper</Company>
-    <Copyright>Copyright © LightMapper Contributors</Copyright>
+    <Authors>HaloMapper Contributors</Authors>
+    <Company>HaloMapper</Company>
+    <Copyright>Copyright © HaloMapper Contributors</Copyright>
     <PackageProjectUrl>https://github.com/0101coding/lightmapper</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/0101coding/lightmapper</RepositoryUrl>

--- a/HaloMapper.sln
+++ b/HaloMapper.sln
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HaloMapper.Tests", "tests\H
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HaloMapper.Extensions.DependencyInjection", "src\HaloMapper.Extensions.DependencyInjection\HaloMapper.Extensions.DependencyInjection.csproj", "{3F9A2D1E-5B8C-4D6F-A7E9-1C2F5B8D9E0A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightMapper.Extensions.DependencyInjection.Tests", "tests\LightMapper.Extensions.DependencyInjection.Tests\LightMapper.Extensions.DependencyInjection.Tests.csproj", "{4A0B3E2F-6C9D-5E7A-B8F0-2D3G6C9F0E1B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HaloMapper.Extensions.DependencyInjection.Tests", "tests\HaloMapper.Extensions.DependencyInjection.Tests\HaloMapper.Extensions.DependencyInjection.Tests.csproj", "{4A0B3E2F-6C9D-5E7A-B8F0-2D3G6C9F0E1B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/LightMapper.Extensions.DependencyInjection/LightMapper.Extensions.DependencyInjection.csproj
+++ b/src/LightMapper.Extensions.DependencyInjection/LightMapper.Extensions.DependencyInjection.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../HaloMapper/HaloMapper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/HaloMapper.Extensions.DependencyInjection.Tests/HaloMapper.Extensions.DependencyInjection.Tests.csproj
+++ b/tests/HaloMapper.Extensions.DependencyInjection.Tests/HaloMapper.Extensions.DependencyInjection.Tests.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/LightMapper.Extensions.DependencyInjection/LightMapper.Extensions.DependencyInjection.csproj" />
-    <ProjectReference Include="../../src/LightMapper/LightMapper.csproj" />
+    <ProjectReference Include="../../src/HaloMapper.Extensions.DependencyInjection/HaloMapper.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="../../src/HaloMapper/HaloMapper.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The files with the previous package name was renamed to fix the issue affecting the build as well enable pushing to the nugget feed